### PR TITLE
Drop privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && \
     curl https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb > /tmp/grafana.deb && \
     dpkg -i /tmp/grafana.deb && \
     rm /tmp/grafana.deb && \
+    curl -L https://github.com/tianon/gosu/releases/download/1.5/gosu-amd64 > /usr/sbin/gosu && \
+    chmod +x /usr/sbin/gosu && \
     apt-get remove -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -16,4 +18,6 @@ VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 
 EXPOSE 3000
 
-ENTRYPOINT ["/usr/sbin/grafana-server", "--homepath=/usr/share/grafana", "--config=/etc/grafana/grafana.ini", "cfg:default.paths.data=/var/lib/grafana", "cfg:default.paths.logs=/var/log/grafana"]
+COPY ./run.sh /run.sh
+
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,14 @@ FROM debian:jessie
 ENV GRAFANA_VERSION 2.1.3
 
 RUN apt-get update && \
-    apt-get -y install libfontconfig wget adduser openssl ca-certificates && \
+    apt-get -y --no-install-recommends install libfontconfig curl ca-certificates && \
     apt-get clean && \
-    wget https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb -O /tmp/grafana.deb && \
+    curl https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb > /tmp/grafana.deb && \
     dpkg -i /tmp/grafana.deb && \
-    rm /tmp/grafana.deb
+    rm /tmp/grafana.deb && \
+    apt-get remove -y curl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+chown -R grafana:grafana /var/lib/grafana /var/log/grafana
+
+exec gosu grafana /usr/sbin/grafana-server  \
+  --homepath=/usr/share/grafana             \
+  --config=/etc/grafana/grafana.ini         \
+  cfg:default.paths.data=/var/lib/grafana   \
+  cfg:default.paths.logs=/var/log/grafana


### PR DESCRIPTION
Instead of running as root, ensure that all needed locations have correct permissions and use dedicated user account. This is fully backwards compatible, old logs and DB files will be `chown`ed on start.

Once #18 is merged, this PR should have much better diff.