### PR TITLE
Fix permission issue when using custom paths

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,12 @@
 #!/bin/sh -e
 
-chown -R grafana:grafana /var/lib/grafana /var/log/grafana
+: "${GF_PATHS_DATA:=/var/lib/grafana}"
+: "${GF_PATHS_LOGS:=/var/log/grafana}"
+
+chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
 
 exec gosu grafana /usr/sbin/grafana-server  \
   --homepath=/usr/share/grafana             \
   --config=/etc/grafana/grafana.ini         \
-  cfg:default.paths.data=/var/lib/grafana   \
-  cfg:default.paths.logs=/var/log/grafana
+  cfg:default.paths.data="$GF_PATHS_DATA"   \
+  cfg:default.paths.logs="$GF_PATHS_LOGS"


### PR DESCRIPTION
This PR fixes the issue with permissions described in #28, by taking into account the values of `GF_PATHS_DATA` and `GF_PATHS_LOGS` environment variables in `run.sh` script.

Related to: #19.
