### PR TITLE
Fix permissions issue: update gosu to 1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     curl https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb > /tmp/grafana.deb && \
     dpkg -i /tmp/grafana.deb && \
     rm /tmp/grafana.deb && \
-    curl -L https://github.com/tianon/gosu/releases/download/1.5/gosu-amd64 > /usr/sbin/gosu && \
+    curl -L https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 > /usr/sbin/gosu && \
     chmod +x /usr/sbin/gosu && \
     apt-get remove -y curl && \
     apt-get autoremove -y && \


### PR DESCRIPTION
Update `gosu` to 1.7 to incorporate tianon/gosu#8 that fixes issues with fd permissions. Thanks @rmbrad for debugging this issue!

See: https://github.com/grafana/grafana-docker/issues/27#issuecomment-184927849.