### PR TITLE
give grafana-server super port powers

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,11 @@
 : "${GF_PATHS_LOGS:=/var/log/grafana}"
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 
+# Run setcap for user only if attempting to use a privileged port
+if [ ! -z "${GF_SERVER_HTTP_PORT}" ] && [ $((GF_SERVER_HTTP_PORT < 1024)) = 1 ]; then
+  setcap 'cap_net_bind_service=+ep' /usr/sbin/grafana-server
+fi
+
 chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
 chown -R grafana:grafana /etc/grafana
 


### PR DESCRIPTION
This change will allow Grafana to be run on port 80 by invoking `setcap` before launching the process if `GF_SERVER_HTTP_PORT` is < `1024`.

Since it only runs `setcap` if that variable is set to a privileged port, this change should not affect existing users who run Grafana on the default port.