### PR TITLE
Allow for installation of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ docker run \
   grafana/grafana
 ```
 
+## Installing plugins for Grafana 3
+
+Pass the plugins you want installed to docker with the `GF_INSTALL_PLUGINS` environment variable as a comma seperated list. This will pass each plugin name to `grafana-cli plugins install ${plugin}`.
+
+```
+docker run \
+  -d \
+  -p 3000:3000 \
+  --name=grafana \
+  -e "GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource" \
+  grafana/grafana
+```
+
 ## Running specific version of Grafana
 
 ```

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,15 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 ~grafana/.aws/credentials
 fi
 
+if [ ! -z ${GF_INSTALL_PLUGINS} ]; then
+  OLDIFS=$IFS
+  IFS=','
+  for plugin in ${GF_INSTALL_PLUGINS}; do
+    grafana-cli plugins install ${plugin}
+  done
+  IFS=$OLDIFS
+fi
+
 exec gosu grafana /usr/sbin/grafana-server  \
   --homepath=/usr/share/grafana             \
   --config=/etc/grafana/grafana.ini         \


### PR DESCRIPTION
This diff adds the ability to install plugins on first run. If plugins are stored on a persisting volume this should only be costly on the first run.

This does not handle the removal of plugins.