### PR TITLE
Create the required opt folder when booting

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,11 @@
 chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
 chown -R grafana:grafana /etc/grafana
 
+if [ ! -d /opt/grafana ] ; then
+    mkdir /opt/grafana
+fi
+chown grafana:grafana /opt/grafana/
+
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     mkdir -p ~grafana/.aws/
     touch ~grafana/.aws/credentials


### PR DESCRIPTION
I just upgraded from Grafana 2.x to 3.x, and was unable to login because it could not write to its opt dir:

```
2016/05/22 10:11:49 [middleware.go:78 initContextWithUserSessionCookie()] [E] Failed to start session%!(EXTRA *os.PathError=mkdir /opt/grafana: permission denied)
2016/05/22 10:11:49 [I] Completed 92.111.49.96 alexnederlof "GET /login HTTP/1.0" 302 Found 24 bytes in 5447us
```

This fix creates the opt dir with the right permissions.