### PR TITLE
Pass arguments to run.sh straight to the Grafana executable.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,9 +39,10 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   IFS=$OLDIFS
 fi
 
-exec gosu grafana /usr/sbin/grafana-server  \
-  --homepath=/usr/share/grafana             \
-  --config=/etc/grafana/grafana.ini         \
-  cfg:default.paths.data="$GF_PATHS_DATA"   \
-  cfg:default.paths.logs="$GF_PATHS_LOGS"   \
-  cfg:default.paths.plugins="$GF_PATHS_PLUGINS"
+exec gosu grafana /usr/sbin/grafana-server      \
+  --homepath=/usr/share/grafana                 \
+  --config=/etc/grafana/grafana.ini             \
+  cfg:default.paths.data="$GF_PATHS_DATA"       \
+  cfg:default.paths.logs="$GF_PATHS_LOGS"       \
+  cfg:default.paths.plugins="$GF_PATHS_PLUGINS" \
+  "$@"


### PR DESCRIPTION
For my specific setup I want to spawn an instance of Grafana, overriding
a very small number of configuration options. Instead of using a custom
configuration file, simply make it possible to pass command line
arguments to Grafana by passing them straight to 'docker run'.