### PR TITLE
Update for easy host volume mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update && \
     curl https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb > /tmp/grafana.deb && \
     dpkg -i /tmp/grafana.deb && \
     rm /tmp/grafana.deb && \
-    curl -L https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 > /usr/sbin/gosu && \
-    chmod +x /usr/sbin/gosu && \
-    apt-get remove -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     curl https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb > /tmp/grafana.deb && \
     dpkg -i /tmp/grafana.deb && \
     rm /tmp/grafana.deb && \
+    apt-get remove -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,7 @@
 : "${GF_PATHS_LOGS:=/var/log/grafana}"
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 
-chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
-chown -R grafana:grafana /etc/grafana
+
 
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     mkdir -p ~grafana/.aws/
@@ -26,7 +25,6 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
         fi
     done
 
-    chown grafana:grafana -R ~grafana/.aws
     chmod 600 ~grafana/.aws/credentials
 fi
 
@@ -39,7 +37,7 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   IFS=$OLDIFS
 fi
 
-exec gosu grafana /usr/sbin/grafana-server  \
+exec /usr/sbin/grafana-server  \
   --homepath=/usr/share/grafana             \
   --config=/etc/grafana/grafana.ini         \
   cfg:default.paths.data="$GF_PATHS_DATA"   \


### PR DESCRIPTION
I have been using the master branch to run this docker container in AWS. However given the elasticity of the cloud, using a data container has the drawback of being lost with the instance itself as they are stored in /var/lib/docker. When run.sh takes ownership of the files, sometimes grafana fails to load as the user (typically 1000) on the host is denied rights to the files. Grafana usually throws the I/O error and stops.

These changes skip running of grafana as the user "grafana", instead runs everything as root, the usual docker way. This allows easy mapping of host volume to persist data on a shared file system.

This way, grafana/influxdb can be run with mapped volumes pointing to NFS/EFS volumes to persist data. Losing an instance does not affect data storage while also allowing a new instance to mount the volume and continue where the old instance left off. With gosu and chown-ing the files as "grafana", this becomes a problem, causing a lack of availability of the grafana container.

Thanks