### PR TITLE
Allow manually setting the UID for grafana

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,11 @@
 : "${GF_PATHS_LOGS:=/var/log/grafana}"
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 
+if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        usermod -u ${UID} grafana
+        groupmod -g ${GID} grafana
+fi
+
 chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
 chown -R grafana:grafana /etc/grafana
 


### PR DESCRIPTION
This code change is to resolve permission issues with host volumes being mapped to the container. As grafana is not run as root and the user "grafana" created within the container gets a random UID, this code help manually set the UID/GID for grafana to meet the host users needs. 

If environment variables are not provided, the code continues as-is, but if say, a UID="1000" and GID="1000" is provided as environment variables during container initiation, grafana's uid/gid are changed. In a scenario where a host volume is mapped to GF_PATHS_DATA, chown-ing with the UID of the container initiating user itself will lead to less of a permissions headache.