### PR TITLE
Fixed logging: removed logging to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
+VOLUME ["/var/lib/grafana", "/etc/grafana"]
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-ARG DOWNLOAD_URL=https://grafanarel.s3.amazonaws.com/builds/grafana_4.1.1-1484211277_amd64.deb
+ARG DOWNLOAD_URL=https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.2.0_amd64.deb
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install libfontconfig curl ca-certificates && \

--- a/run.sh
+++ b/run.sh
@@ -42,6 +42,7 @@ fi
 exec gosu grafana /usr/sbin/grafana-server      \
   --homepath=/usr/share/grafana                 \
   --config=/etc/grafana/grafana.ini             \
+  cfg:default.log.mode="console"                \
   cfg:default.paths.data="$GF_PATHS_DATA"       \
   cfg:default.paths.logs="$GF_PATHS_LOGS"       \
   cfg:default.paths.plugins="$GF_PATHS_PLUGINS" \


### PR DESCRIPTION
hey guys,

logging to a file inside a container can have some ugly side effects (running out of disk space etc.)

I've overwritten the default config of `log.mode = 'file console'` to `log.mode = 'console'` inside the `run.sh`.

Also I removed the now unnecessary volume for `/var/logs/grafana`

Would be nice if you could pull this 😃 

thanks