### PR TITLE
VOLUME and docker volume plugins don't mix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM debian:jessie
 
-ARG DOWNLOAD_URL
-
 RUN apt-get update && \
     apt-get -y --no-install-recommends install libfontconfig curl ca-certificates && \
     apt-get clean && \
-    curl ${DOWNLOAD_URL} > /tmp/grafana.deb && \
+    curl https://s3-us-west-2.amazonaws.com/grafana-releases/master/grafana_latest_amd64.deb > /tmp/grafana.deb && \
     dpkg -i /tmp/grafana.deb && \
     rm /tmp/grafana.deb && \
     curl -L https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 > /usr/sbin/gosu && \
@@ -13,8 +11,6 @@ RUN apt-get update && \
     apt-get remove -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-
-VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 
 EXPOSE 3000
 


### PR DESCRIPTION
When using a docker volume plugin, the volumes get created at run time, and get mounted over the directories listed in VOLUME, so none of the installed files are there any more!

All I did was remove the VOLUME directive in Dockerfile.