### PR TITLE
Chown to grafana user HTTPS certification file and key.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,14 @@
 chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
 chown -R grafana:grafana /etc/grafana
 
+if [ ! -z "${GF_SERVER_CERT_FILE}" ]; then
+	chown -R grafana:grafana "${GF_SERVER_CERT_FILE}"
+fi
+
+if [ ! -z "${GF_SERVER_CERT_KEY}" ]; then
+	chown -R grafana:grafana "${GF_SERVER_CERT_KEY}"
+fi
+
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     mkdir -p ~grafana/.aws/
     touch ~grafana/.aws/credentials


### PR DESCRIPTION
Goal is to chown certification files to grafana user in order to avoid denied error message when Grafana is trying to read certification files on startup. 