### PR TITLE
allow skipping chown when starting grafana

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,10 @@
 : "${GF_PATHS_LOGS:=/var/log/grafana}"
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 
-chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
-chown -R grafana:grafana /etc/grafana
+if [ -z "${GF_SKIP_PATHS_CHOWN}" ]; then
+    chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
+    chown -R grafana:grafana /etc/grafana
+fi
 
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     mkdir -p ~grafana/.aws/


### PR DESCRIPTION
We are mounting grafana data/plugins dirs from a network shared drive that we ensure is readable and writable by a grafana user but we want to avoid chowning files as part of a start-up script.
