### PR TITLE
make a target docker repo an optional param

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,14 +3,16 @@
 _grafana_tag=$1
 _grafana_version=${_grafana_tag:1}
 
+_docker_repo=${2:-grafana/grafana}
+
 if [ "$_grafana_version" != "" ]; then
 	echo "Building version ${_grafana_version}"
 	echo "Download url: https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_${_grafana_version}_amd64.deb"
 	docker build \
 		--build-arg DOWNLOAD_URL=https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_${_grafana_version}_amd64.deb \
-		--tag "grafana/grafana:${_grafana_version}" \
+		--tag "${_docker_repo}:${_grafana_version}" \
 		--no-cache=true .
-	docker tag grafana/grafana:${_grafana_version} grafana/grafana:latest
+	docker tag ${_docker_repo}:${_grafana_version} ${_docker_repo}:latest
 
 else
 	echo "Building latest for master"


### PR DESCRIPTION
When working on a fork it would be good to be able to change the target docker repo when building the project.

The default behaviour is the same as before the change.