### PR TITLE
gosu grafana when installing plugins

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -35,7 +35,7 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   IFS=','
   for plugin in ${GF_INSTALL_PLUGINS}; do
     IFS=$OLDIFS
-    grafana-cli  --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    gosu grafana grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
   done
 fi
 


### PR DESCRIPTION
Similarly to starting the server we should `gosu grafana` when installing plugins to ensure correct user/permissions.