### PR TITLE
Pass "$@" to grafana-server before 'cfg:' options

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -43,8 +43,8 @@ fi
 exec gosu grafana /usr/sbin/grafana-server      \
   --homepath=/usr/share/grafana                 \
   --config="$GF_PATHS_CONFIG"                   \
+  "$@"                                          \
   cfg:default.log.mode="console"                \
   cfg:default.paths.data="$GF_PATHS_DATA"       \
   cfg:default.paths.logs="$GF_PATHS_LOGS"       \
-  cfg:default.paths.plugins="$GF_PATHS_PLUGINS" \
-  "$@"
+  cfg:default.paths.plugins="$GF_PATHS_PLUGINS"


### PR DESCRIPTION
Passing the provided args (`$@`) at the end of the command line
invocation results in grafana-server ignoring them. This doesn't happen
if they are passed before the 'cfg'' directives.

 o reproduce, run `docker run --rm grafana/grafana:4.6.2 -v`. This
should print `Version 4.6.2 (commit: 8db5f08)` but instead starts
Grafana.