### PR TITLE
Resets AWS credentials file on startup.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
 
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     mkdir -p ~grafana/.aws/
-    touch ~grafana/.aws/credentials
+    > ~grafana/.aws/credentials
 
     for profile in ${GF_AWS_PROFILES}; do
         access_key_varname="GF_AWS_${profile}_ACCESS_KEY_ID"


### PR DESCRIPTION
When the AWS credentials are configured
using env vars the config will be reset
each startup.

The credentials file will not be reset if env
vars aren't used.

Fixes #127 