### PR TITLE
Add workdir to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ EXPOSE 3000
 
 COPY ./run.sh /run.sh
 
+WORKDIR /
+
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
When running `grafana/grafana` under the [Mesos containerizer](http://mesos.apache.org/documentation/latest/mesos-containerizer/), the /run.sh entrypoint fails with the message `error getting work directory: failed to stat '.': Permission denied`

This is caused by a call to [os.Getwd](https://golang.org/pkg/os/#Getwd). Absent an explicitly set workdir, the Mesos containerizer will set the working directory to a chrooted sandbox directory which root does not have permissions to stat. 

Adding a workdir of `/` ensures that the image behaves the same under the Mesos containerizer as in the Docker runtime.