### PR TITLE
Image improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 ARG GRAFANA_VERSION="latest"
 ARG GF_HOME="/usr/share/grafana"
+ARG GF_UID="472"
+ARG GF_GID="472"
 
-RUN apt-get update && apt-get install -qq -y wget tar sqlite libfontconfig curl ca-certificates && \
-    wget -O /tmp/grafana.tar.gz https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz && \
+RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-certificates && \
+    curl -o /tmp/grafana.tar.gz https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz && \
     tar -zxvf /tmp/grafana.tar.gz -C /tmp && rm /tmp/grafana.tar.gz && \
     mv /tmp/grafana-* $GF_HOME && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-    
-RUN mkdir -p /etc/grafana/provisioning/datasources && \
+
+RUN groupadd -r -g $GF_GID grafana && \
+    useradd -r -u $GF_UID -g grafana grafana && \
+    mkdir -p /etc/grafana/provisioning/datasources && \
     mkdir -p /etc/grafana/provisioning/dashboards && \
     mkdir -p /var/lib/grafana/plugins && \
     mkdir -p /var/log/grafana && \
@@ -18,9 +22,20 @@ RUN mkdir -p /etc/grafana/provisioning/datasources && \
     cp $GF_HOME/conf/ldap.toml /etc/grafana/ldap.toml && \
     cp $GF_HOME/bin/grafana-server /usr/sbin/grafana-server && \
     cp $GF_HOME/bin/grafana-cli /usr/sbin/grafana-cli && \
-    chown -R nobody:nogroup /var/lib/grafana && \
-    chown -R nobody:nogroup $GF_HOME && \
-    chown -R nobody:nogroup /var/log/grafana
+    chown -R grafana:grafana /var/lib/grafana && \
+    chown -R grafana:grafana $GF_HOME && \
+    chown -R grafana:grafana /var/log/grafana
+
+ARG GF_INSTALL_PLUGINS=""
+
+RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
+      OLDIFS=$IFS; \
+      IFS=','; \
+      for plugin in ${GF_INSTALL_PLUGINS}; do \
+        IFS=$OLDIFS; \
+        grafana-cli --pluginsDir "/var/lib/grafana/plugins" plugins install ${plugin}; \
+      done; \
+    fi
 
 VOLUME ["/var/lib/grafana"]
 
@@ -28,6 +43,6 @@ EXPOSE 3000
 
 COPY ./run.sh /run.sh
 
-USER nobody
+USER grafana
 
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
     GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
     GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
-RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-certificates && \
+RUN apt-get update && apt-get install -qq -y tar libfontconfig curl ca-certificates && \
     mkdir -p "$GF_PATHS_HOME/.aws" && \
     curl "$GRAFANA_URL" | tar xfvz - --strip-components=1 -C "$GF_PATHS_HOME" && \
     apt-get autoremove -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,20 @@ ARG GRAFANA_VERSION="latest"
 ARG GF_UID="472"
 ARG GF_GID="472"
 
-ENV GF_PATHS_CONFIG="/etc/grafana/grafana.ini"
-ENV GF_PATHS_DATA="/var/lib/grafana"
-ENV GF_PATHS_HOME="/usr/share/grafana"
-ENV GF_PATHS_LOGS="/var/log/grafana"
-ENV GF_PATHS_PLUGINS="/var/lib/grafana/plugins"
-ENV GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+    GF_PATHS_DATA="/var/lib/grafana" \
+    GF_PATHS_HOME="/usr/share/grafana" \
+    GF_PATHS_LOGS="/var/log/grafana" \
+    GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+    GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
 RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-certificates && \
     mkdir -p "$GF_PATHS_HOME" && \
     curl https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz | tar xfvz - --strip-components=1 -C "$GF_PATHS_HOME" && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN groupadd -r -g $GF_GID grafana && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -r -g $GF_GID grafana && \
     useradd -r -u $GF_UID -g grafana grafana && \
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
@@ -25,8 +25,6 @@ RUN groupadd -r -g $GF_GID grafana && \
              "$GF_PATHS_LOGS" && \
     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
-    cp "$GF_PATHS_HOME/bin/grafana-server" /usr/sbin/grafana-server && \
-    cp "$GF_PATHS_HOME/bin/grafana-cli" /usr/sbin/grafana-cli && \
     chown -R grafana:grafana "$GF_PATHS_DATA" && \
     chown -R grafana:grafana "$GF_PATHS_HOME" && \
     chown -R grafana:grafana "$GF_PATHS_LOGS"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
     GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
 RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-certificates && \
-    mkdir -p "$GF_PATHS_HOME" && \
+    mkdir -p "$GF_PATHS_HOME/.aws" && \
     curl https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz | tar xfvz - --strip-components=1 -C "$GF_PATHS_HOME" && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
@@ -21,24 +21,14 @@ RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-ce
     useradd -r -u $GF_UID -g grafana grafana && \
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
-             "$GF_PATHS_PLUGINS" \
-             "$GF_PATHS_LOGS" && \
+             "$GF_PATHS_LOGS" \
+             "$GF_PATHS_DATA" && \
     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
     chown -R grafana:grafana "$GF_PATHS_DATA" && \
-    chown -R grafana:grafana "$GF_PATHS_HOME" && \
-    chown -R grafana:grafana "$GF_PATHS_LOGS"
-
-ARG GF_INSTALL_PLUGINS=""
-
-RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
-      OLDIFS=$IFS; \
-      IFS=','; \
-      for plugin in ${GF_INSTALL_PLUGINS}; do \
-        IFS=$OLDIFS; \
-        grafana-cli --pluginsDir "$GF_PATHS_PLUGINS" plugins install ${plugin}; \
-      done; \
-    fi
+    chown -R grafana:grafana "$GF_PATHS_HOME/.aws" && \
+    chown -R grafana:grafana "$GF_PATHS_LOGS" && \
+    chmod 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS"
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,35 @@
 FROM debian:stretch-slim
 
 ARG GRAFANA_VERSION="latest"
-ARG GF_HOME="/usr/share/grafana"
 ARG GF_UID="472"
 ARG GF_GID="472"
 
+ENV GF_PATHS_CONFIG="/etc/grafana/grafana.ini"
+ENV GF_PATHS_DATA="/var/lib/grafana"
+ENV GF_PATHS_HOME="/usr/share/grafana"
+ENV GF_PATHS_LOGS="/var/log/grafana"
+ENV GF_PATHS_PLUGINS="/var/lib/grafana/plugins"
+ENV GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+
 RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-certificates && \
-    curl -o /tmp/grafana.tar.gz https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz && \
-    tar -zxvf /tmp/grafana.tar.gz -C /tmp && rm /tmp/grafana.tar.gz && \
-    mv /tmp/grafana-* $GF_HOME && \
+    mkdir -p "$GF_PATHS_HOME" && \
+    curl https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz | tar xfvz - --strip-components=1 -C "$GF_PATHS_HOME" && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r -g $GF_GID grafana && \
     useradd -r -u $GF_UID -g grafana grafana && \
-    mkdir -p /etc/grafana/provisioning/datasources && \
-    mkdir -p /etc/grafana/provisioning/dashboards && \
-    mkdir -p /var/lib/grafana/plugins && \
-    mkdir -p /var/log/grafana && \
-    cp $GF_HOME/conf/sample.ini /etc/grafana/grafana.ini && \
-    cp $GF_HOME/conf/ldap.toml /etc/grafana/ldap.toml && \
-    cp $GF_HOME/bin/grafana-server /usr/sbin/grafana-server && \
-    cp $GF_HOME/bin/grafana-cli /usr/sbin/grafana-cli && \
-    chown -R grafana:grafana /var/lib/grafana && \
-    chown -R grafana:grafana $GF_HOME && \
-    chown -R grafana:grafana /var/log/grafana
+    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+             "$GF_PATHS_PROVISIONING/dashboards" \
+             "$GF_PATHS_PLUGINS" \
+             "$GF_PATHS_LOGS" && \
+    cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
+    cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
+    cp "$GF_PATHS_HOME/bin/grafana-server" /usr/sbin/grafana-server && \
+    cp "$GF_PATHS_HOME/bin/grafana-cli" /usr/sbin/grafana-cli && \
+    chown -R grafana:grafana "$GF_PATHS_DATA" && \
+    chown -R grafana:grafana "$GF_PATHS_HOME" && \
+    chown -R grafana:grafana "$GF_PATHS_LOGS"
 
 ARG GF_INSTALL_PLUGINS=""
 
@@ -33,11 +38,11 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
       IFS=','; \
       for plugin in ${GF_INSTALL_PLUGINS}; do \
         IFS=$OLDIFS; \
-        grafana-cli --pluginsDir "/var/lib/grafana/plugins" plugins install ${plugin}; \
+        grafana-cli --pluginsDir "$GF_PATHS_PLUGINS" plugins install ${plugin}; \
       done; \
     fi
 
-VOLUME ["/var/lib/grafana"]
+VOLUME [$GF_PATHS_DATA]
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,6 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
       done; \
     fi
 
-VOLUME [$GF_PATHS_DATA]
-
 EXPOSE 3000
 
 COPY ./run.sh /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN mkdir -p /etc/grafana/provisioning/datasources && \
     cp $GF_HOME/bin/grafana-server /usr/sbin/grafana-server && \
     cp $GF_HOME/bin/grafana-cli /usr/sbin/grafana-cli && \
     chown -R nobody:nogroup /var/lib/grafana && \
-    chown -R nobody:nogroup $GF_HOME
+    chown -R nobody:nogroup $GF_HOME && \
+    chown -R nobody:nogroup /var/log/grafana
 
 VOLUME ["/var/lib/grafana"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,16 @@ RUN mkdir -p /etc/grafana/provisioning/datasources && \
     cp $GF_HOME/conf/sample.ini /etc/grafana/grafana.ini && \
     cp $GF_HOME/conf/ldap.toml /etc/grafana/ldap.toml && \
     cp $GF_HOME/bin/grafana-server /usr/sbin/grafana-server && \
-    cp $GF_HOME/bin/grafana-cli /usr/sbin/grafana-cli
+    cp $GF_HOME/bin/grafana-cli /usr/sbin/grafana-cli && \
+    chown -R nobody:nogroup /var/lib/grafana && \
+    chown -R nobody:nogroup $GF_HOME
 
 VOLUME ["/var/lib/grafana"]
 
 EXPOSE 3000
 
 COPY ./run.sh /run.sh
+
+USER nobody
 
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:stretch-slim
 
 ARG GRAFANA_VERSION="latest"
+ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz"
 ARG GF_UID="472"
 ARG GF_GID="472"
 
@@ -14,7 +15,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-certificates && \
     mkdir -p "$GF_PATHS_HOME/.aws" && \
-    curl https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz | tar xfvz - --strip-components=1 -C "$GF_PATHS_HOME" && \
+    curl "$GRAFANA_URL" | tar xfvz - --strip-components=1 -C "$GF_PATHS_HOME" && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -r -g $GF_GID grafana && \
@@ -22,13 +23,12 @@ RUN apt-get update && apt-get install -qq -y tar sqlite libfontconfig curl ca-ce
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_LOGS" \
+             "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \
     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
-    chown -R grafana:grafana "$GF_PATHS_DATA" && \
-    chown -R grafana:grafana "$GF_PATHS_HOME/.aws" && \
-    chown -R grafana:grafana "$GF_PATHS_LOGS" && \
-    chmod 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS"
+    chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" && \
+    chmod 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS"
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM debian:stretch-slim
 
-ARG GRAFANA_VERSION="latest"
-ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$GRAFANA_VERSION.linux-x64.tar.gz"
+ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/master/grafana-latest.linux-x64.tar.gz"
 ARG GF_UID="472"
 ARG GF_GID="472"
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ docker run \
 ```
 
 Note: An unnamed volume will be created for you when you boot Grafana,
-using `docker volume create grafana-storage` just makes it easer to find.
+using `docker volume create grafana-storage` just makes it easier to find
+by giving it a name.
 
 ## Installing plugins for Grafana 3
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/grafana/grafana-docker.svg?style=svg)](https://circleci.com/gh/grafana/grafana-docker)
 
-This project builds a Docker image with the latest master build of Grafana.
+This project builds a Docker image for Grafana.
 
 ## Running your Grafana container
 
@@ -14,7 +14,7 @@ docker run -d --name=grafana -p 3000:3000 grafana/grafana
 
 Try it out, default admin user is admin/admin.
 
-In case port 3000 is closed for external clients or you there is no access 
+In case port 3000 is closed for external clients or there is no access
 to the browser - you may test it by issuing:
   curl -i localhost:3000/login
 Make sure that you are getting "...200 OK" in response.
@@ -59,7 +59,7 @@ Note: An unnamed volume will be created for you when you boot Grafana,
 using `docker volume create grafana-storage` just makes it easier to find
 by giving it a name.
 
-## Installing plugins for Grafana 3
+## Installing plugins for Grafana
 
 Pass the plugins you want installed to docker with the `GF_INSTALL_PLUGINS` environment variable as a comma seperated list. This will pass each plugin name to `grafana-cli plugins install ${plugin}`.
 
@@ -74,27 +74,19 @@ docker run \
 
 ## Building a custom Grafana image with pre-installed plugins
 
-Dockerfile:
-```Dockerfile
-FROM grafana/grafana:master
-ENV GF_PATHS_PLUGINS=/opt/grafana-plugins
-USER root
-RUN mkdir -p $GF_PATHS_PLUGINS && chown nobody:nogroup $GF_PATHS_PLUGINS
-USER nobody
-RUN grafana-cli --pluginsDir $GF_PATHS_PLUGINS plugins install grafana-clock-panel && \
-    grafana-cli --pluginsDir $GF_PATHS_PLUGINS plugins install grafana-simple-json-datasource
-```
-
-Add lines with `grafana-cli ...` for each plugin you wish to install in your custom image. Don't forget to specify what version of Grafana you wish to build from (replace master in the example).
+The `custom/` folder includes a `Dockerfile` that can be used to build a custom Grafana image.  It accepts `GRAFANA_VERSION` and `GF_INSTALL_PLUGINS` as build arguments.
 
 Example of how to build and run:
 ```bash
-docker build -t grafana:master-with-plugins . 
+cd custom
+docker build -t grafana:latest-with-plugins \
+  --build-arg "GRAFANA_VERSION=latest" \
+  --build-arg "GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource" .
 docker run \
   -d \
   -p 3000:3000 \
   --name=grafana \
-  grafana:master-with-plugins
+  grafana:latest-with-plugins
 ```
 
 ## Running specific version of Grafana
@@ -132,6 +124,9 @@ Supported variables:
 - `GF_AWS_${profile}_REGION`: AWS region (optional).
 
 ## Changelog
+
+### v5.1.0
+* Complete overhaul
 
 ### v4.2.0
 * Plugins are now installed into ${GF_PATHS_PLUGINS}

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ _docker_repo=${2:-grafana/grafana}
 if [ "$_grafana_version" != "" ]; then
 	echo "Building version ${_grafana_version}"
 	docker build \
-		--build-arg GRAFANA_VERSION=${_grafana_version} \
+		--build-arg GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${_grafana_version}.linux-x64.tar.gz" \
 		--tag "${_docker_repo}:${_grafana_version}" \
 		--no-cache=true .
 	docker tag ${_docker_repo}:${_grafana_version} ${_docker_repo}:latest

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-_grafana_tag=$1
-_grafana_version=${_grafana_tag:1}
+_grafana_version=$1
 
 if [ "$_grafana_version" != "" ]; then
 	echo "Building version ${_grafana_version}"
-	echo "Download url: https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_${_grafana_version}_amd64.deb"
 	docker build \
-		--build-arg DOWNLOAD_URL=https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_${_grafana_version}_amd64.deb \
+		--build-arg GRAFANA_VERSION=${_grafana_version} \
 		--tag "grafana/grafana:${_grafana_version}" \
 		--no-cache=true .
 	docker tag grafana/grafana:${_grafana_version} grafana/grafana:latest
@@ -16,5 +14,5 @@ else
 	echo "Building latest for master"
 	docker build \
 		--tag "grafana/grafana:master" \
-		--no-cache=true .
+		.
 fi

--- a/custom/Dockerfile
+++ b/custom/Dockerfile
@@ -1,0 +1,16 @@
+ARG GRAFANA_VERSION="latest"
+
+FROM grafana/grafana:${GRAFANA_VERSION}
+
+USER grafana
+
+ARG GF_INSTALL_PLUGINS=""
+
+RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
+    OLDIFS=$IFS; \
+        IFS=','; \
+    for plugin in ${GF_INSTALL_PLUGINS}; do \
+        IFS=$OLDIFS; \
+        grafana-cli --pluginsDir "$GF_PATHS_PLUGINS" plugins install ${plugin}; \
+    done; \
+fi

--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,5 @@
 #!/bin/bash -e
 
-: "${GF_PATHS_CONFIG:=/etc/grafana/grafana.ini}"
-: "${GF_PATHS_DATA:=/var/lib/grafana}"
-: "${GF_PATHS_HOME:=/usr/share/grafana}"
-: "${GF_PATHS_LOGS:=/var/log/grafana}"
-: "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
-: "${GF_PATHS_PROVISIONING:=/etc/grafana/provisioning}"
-
 PERMISSIONS_OK=0
 
 if [ ! -r "$GF_PATHS_CONFIG" ]; then

--- a/run.sh
+++ b/run.sh
@@ -20,10 +20,13 @@ fi
 if [ $PERMISSIONS_OK -eq 1 ]; then
     echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later"
 fi
- 
+
+if [ ! -d "$GF_PATHS_PLUGINS" ]; then
+    mkdir "$GF_PATHS_PLUGINS"
+fi
+
 
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
-    mkdir -p "$GF_PATHS_HOME/.aws/"
     > "$GF_PATHS_HOME/.aws/credentials"
 
     for profile in ${GF_AWS_PROFILES}; do

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,29 @@
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 : "${GF_PATHS_PROVISIONING:=/etc/grafana/provisioning}"
 
+PERMISSIONS_OK=0
+
+if [ ! -r "$GF_PATHS_CONFIG" ]; then
+    echo "GF_PATHS_CONFIG='$GF_PATHS_CONFIG' is not readable."
+    PERMISSIONS_OK=1
+fi
+
+if [ ! -w "$GF_PATHS_DATA" ]; then
+    echo "GF_PATHS_DATA='$GF_PATHS_DATA' is not writable."
+    PERMISSIONS_OK=1
+fi
+
+if [ ! -r "$GF_PATHS_HOME" ]; then
+    echo "GF_PATHS_HOME='$GF_PATHS_HOME' is not readable."
+    PERMISSIONS_OK=1
+fi
+
+
+if [ $PERMISSIONS_OK -eq 1 ]; then
+    echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/"
+fi
+ 
+
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     mkdir -p "$GF_PATHS_HOME/.aws/"
     > "$GF_PATHS_HOME/.aws/credentials"

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   done
 fi
 
-exec /usr/sbin/grafana-server                               \
+exec grafana-server                                         \
   --homepath="$GF_PATHS_HOME"                               \
   --config="$GF_PATHS_CONFIG"                               \
   cfg:default.log.mode="console"                            \

--- a/run.sh
+++ b/run.sh
@@ -26,7 +26,7 @@ fi
 
 
 if [ $PERMISSIONS_OK -eq 1 ]; then
-    echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/"
+    echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later"
 fi
  
 

--- a/run.sh
+++ b/run.sh
@@ -6,11 +6,9 @@
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 : "${GF_PATHS_PROVISIONING:=/etc/grafana/provisioning}"
 
-chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS"
-
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
-    mkdir -p ~grafana/.aws/
-    > ~grafana/.aws/credentials
+    mkdir -p /usr/share/grafana/.aws/
+    > /usr/share/grafana/.aws/credentials
 
     for profile in ${GF_AWS_PROFILES}; do
         access_key_varname="GF_AWS_${profile}_ACCESS_KEY_ID"
@@ -18,17 +16,17 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
         region_varname="GF_AWS_${profile}_REGION"
 
         if [ ! -z "${!access_key_varname}" -a ! -z "${!secret_key_varname}" ]; then
-            echo "[${profile}]" >> ~grafana/.aws/credentials
-            echo "aws_access_key_id = ${!access_key_varname}" >> ~grafana/.aws/credentials
-            echo "aws_secret_access_key = ${!secret_key_varname}" >> ~grafana/.aws/credentials
+            echo "[${profile}]" >> /usr/share/grafana/.aws/credentials
+            echo "aws_access_key_id = ${!access_key_varname}" >> /usr/share/grafana/.aws/credentials
+            echo "aws_secret_access_key = ${!secret_key_varname}" >> /usr/share/grafana/.aws/credentials
             if [ ! -z "${!region_varname}" ]; then
-                echo "region = ${!region_varname}" >> ~grafana/.aws/credentials
+                echo "region = ${!region_varname}" >> /usr/share/grafana/.aws/credentials
             fi
         fi
     done
 
-    chown grafana:grafana -R ~grafana/.aws
-    chmod 600 ~grafana/.aws/credentials
+#    chown grafana:grafana -R ~grafana/.aws
+#    chmod 600 ~grafana/.aws/credentials
 fi
 
 if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
@@ -36,11 +34,11 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   IFS=','
   for plugin in ${GF_INSTALL_PLUGINS}; do
     IFS=$OLDIFS
-    gosu grafana grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
   done
 fi
 
-exec gosu grafana /usr/sbin/grafana-server              \
+exec /usr/sbin/grafana-server                           \
   --homepath=/usr/share/grafana                         \
   --config="$GF_PATHS_CONFIG"                           \
   cfg:default.log.mode="console"                        \

--- a/run.sh
+++ b/run.sh
@@ -2,13 +2,14 @@
 
 : "${GF_PATHS_CONFIG:=/etc/grafana/grafana.ini}"
 : "${GF_PATHS_DATA:=/var/lib/grafana}"
+: "${GF_PATHS_HOME:=/usr/share/grafana}"
 : "${GF_PATHS_LOGS:=/var/log/grafana}"
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
 : "${GF_PATHS_PROVISIONING:=/etc/grafana/provisioning}"
 
 if [ ! -z ${GF_AWS_PROFILES+x} ]; then
-    mkdir -p /usr/share/grafana/.aws/
-    > /usr/share/grafana/.aws/credentials
+    mkdir -p "$GF_PATHS_HOME/.aws/"
+    > "$GF_PATHS_HOME/.aws/credentials"
 
     for profile in ${GF_AWS_PROFILES}; do
         access_key_varname="GF_AWS_${profile}_ACCESS_KEY_ID"
@@ -16,17 +17,16 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
         region_varname="GF_AWS_${profile}_REGION"
 
         if [ ! -z "${!access_key_varname}" -a ! -z "${!secret_key_varname}" ]; then
-            echo "[${profile}]" >> /usr/share/grafana/.aws/credentials
-            echo "aws_access_key_id = ${!access_key_varname}" >> /usr/share/grafana/.aws/credentials
-            echo "aws_secret_access_key = ${!secret_key_varname}" >> /usr/share/grafana/.aws/credentials
+            echo "[${profile}]" >> "$GF_PATHS_HOME/.aws/credentials"
+            echo "aws_access_key_id = ${!access_key_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+            echo "aws_secret_access_key = ${!secret_key_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
             if [ ! -z "${!region_varname}" ]; then
-                echo "region = ${!region_varname}" >> /usr/share/grafana/.aws/credentials
+                echo "region = ${!region_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
             fi
         fi
     done
 
-#    chown grafana:grafana -R ~grafana/.aws
-#    chmod 600 ~grafana/.aws/credentials
+    chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
 if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
@@ -38,12 +38,12 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   done
 fi
 
-exec /usr/sbin/grafana-server                           \
-  --homepath=/usr/share/grafana                         \
-  --config="$GF_PATHS_CONFIG"                           \
-  cfg:default.log.mode="console"                        \
-  cfg:default.paths.data="$GF_PATHS_DATA"               \
-  cfg:default.paths.logs="$GF_PATHS_LOGS"               \
-  cfg:default.paths.plugins="$GF_PATHS_PLUGINS"         \
-  cfg:default.paths.provisioning=$GF_PATHS_PROVISIONING \
+exec /usr/sbin/grafana-server                               \
+  --homepath="$GF_PATHS_HOME"                               \
+  --config="$GF_PATHS_CONFIG"                               \
+  cfg:default.log.mode="console"                            \
+  cfg:default.paths.data="$GF_PATHS_DATA"                   \
+  cfg:default.paths.logs="$GF_PATHS_LOGS"                   \
+  cfg:default.paths.plugins="$GF_PATHS_PLUGINS"             \
+  cfg:default.paths.provisioning="$GF_PATHS_PROVISIONING"   \
   "$@"


### PR DESCRIPTION
*Important:* do not merge before we are ready to release 5.1.

Re-structured docker image which makes it easier to control what user Grafana runs as, removes default volumes and no longer chowns any folders or files on startup. The default user has been changed from grafana (id: 104) to grafana (id: 472) which will cause permission problems if used together with files created in a previous version. The main grafana docs has been updated to help solve these issues. Docs PR here https://github.com/grafana/grafana/pull/11365. 

Closes #141
Closes #140 
Closes #50 
Closes #124 
Closes  #102 

