### PR TITLE
Add the ability to use a specific url during plugin install

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -52,7 +52,13 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   IFS=','
   for plugin in ${GF_INSTALL_PLUGINS}; do
     IFS=$OLDIFS
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    if [[ $plugin =~ .*\;.* ]]; then
+        pluginUrl=$(echo "$plugin" | cut -d';' -f 1)
+        pluginWithoutUrl=$(echo "$plugin" | cut -d';' -f 2)
+        grafana-cli --pluginUrl "${pluginUrl}" --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${pluginWithoutUrl}
+    else
+        grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    fi
   done
 fi
 


### PR DESCRIPTION
Hello there !

I missed the ability to pass the `pluginUrl` when running the container (I could've extended and plublished the image but I'd prefer that in the official repository).
I made a small change in the run.sh script so that you can use `http://mycompany.com/mysuperplugin.zip;mysuperplugin` syntax to specify the plugin Url.
I'm not sure the delimiter is good or if we should do something else to keep things clean, anyway I'm glad to contribute.

(PS: thanks for your job dear maintainers, you are amazing. )