### PR TITLE
Tag master builds of Grafana with the specific changeset.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,14 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: docker info
-      - run: echo $GRAFANA_VERSION
-      - run: ./build.sh ${GRAFANA_VERSION}
-      - deploy:
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              ./push_to_docker_hub.sh ${GRAFANA_VERSION}
+      - run: |
+          if [ -n "$GRAFANA_VERSION" ]; then
+            ./build.sh "$GRAFANA_VERSION"
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+            ./push_to_docker_hub.sh "$GRAFANA_VERSION"
+
+            if echo "$GRAFANA_VERSION" | grep -q "^master-"; then
+              apk add --no-cache curl
+              ./deploy_to_k8s.sh "grafana/grafana-dev:$GRAFANA_VERSION"
             fi
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
 
-ARG GRAFANA_URL
+ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/master/grafana-latest.linux-x64.tar.gz"
 ARG GF_UID="472"
 ARG GF_GID="472"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
 
-ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/master/grafana-latest.linux-x64.tar.gz"
+ARG GRAFANA_URL
 ARG GF_UID="472"
 ARG GF_GID="472"
 

--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,28 @@
 #!/bin/sh
 
 _grafana_tag=$1
-_grafana_version=$(echo ${_grafana_tag} | cut -d "v" -f 2)
-_docker_repo=${2:-grafana/grafana}
 
-
-echo ${_grafana_version}
-
-if [ "$_grafana_version" != "" ]; then
-	echo "Building version ${_grafana_version}"
-	docker build \
-		--build-arg GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${_grafana_version}.linux-amd64.tar.gz" \
-		--tag "${_docker_repo}:${_grafana_version}" \
-		--no-cache=true .
-	docker tag ${_docker_repo}:${_grafana_version} ${_docker_repo}:latest
+# If the tag starts with v, treat this as a official release
+if echo "$_grafana_tag" | grep -q "^v"; then
+	_grafana_version=$(echo "${_grafana_tag}" | cut -d "v" -f 2)
+	_grafana_url="https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${_grafana_version}.linux-amd64.tar.gz"
+	_docker_repo=${2:-grafana/grafana}
 else
-	echo "Building latest for master"
-	docker build \
-		--tag "grafana/grafana:master" \
-		.
+	_grafana_version=$_grafana_tag
+	_grafana_url="https://s3-us-west-2.amazonaws.com/grafana-releases/master/grafana-${_grafana_version}.linux-x64.tar.gz"
+	_docker_repo=${2:-grafana/grafana-dev}
+fi
+
+echo "Building ${_docker_repo}:${_grafana_version} from ${_grafana_url}"
+
+docker build \
+	--build-arg GRAFANA_URL="${_grafana_url}" \
+	--tag "${_docker_repo}:${_grafana_version}" \
+	--no-cache=true .
+
+# Tag as 'latest' for official release; otherwise tag as grafana/grafana:master
+if echo "$_grafana_tag" | grep -q "^v"; then
+	docker tag "${_docker_repo}:${_grafana_version}" "${_docker_repo}:latest"
+else
+	docker tag "${_docker_repo}:${_grafana_version}" "grafana/grafana:master"
 fi

--- a/deploy_to_k8s.sh
+++ b/deploy_to_k8s.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+curl -s --header "Content-Type: application/json" \
+     --data "{\"build_parameters\": {\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$1\"}}" \
+     --request POST \
+     https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN

--- a/push_to_docker_hub.sh
+++ b/push_to_docker_hub.sh
@@ -1,16 +1,22 @@
 #!/bin/sh
 
 _grafana_tag=$1
-_grafana_version=$(echo ${_grafana_tag} | cut -d "v" -f 2)
 
-if [ "$_grafana_version" != "" ]; then
-	echo "pushing grafana/grafana:${_grafana_version}"
-	docker push grafana/grafana:${_grafana_version}
+# If the tag starts with v, treat this as a official release
+if echo "$_grafana_tag" | grep -q "^v"; then
+	_grafana_version=$(echo "${_grafana_tag}" | cut -d "v" -f 2)
+	_docker_repo=${2:-grafana/grafana}
+else
+	_grafana_version=$_grafana_tag
+	_docker_repo=${2:-grafana/grafana-dev}
+fi
 
-	if echo "$_grafana_version" | grep -viqF beta; then
-		echo "pushing grafana/grafana:latest"
-		docker push grafana/grafana:latest
-	fi
+echo "pushing ${_docker_repo}:${_grafana_version}"
+docker push "${_docker_repo}:${_grafana_version}"
+
+if echo "$_grafana_tag" | grep -q "^v"; then
+	echo "pushing ${_docker_repo}:latest"
+	docker push "${_docker_repo}:latest"
 else
 	echo "pushing grafana/grafana:master"
 	docker push grafana/grafana:master


### PR DESCRIPTION
This PR changes the behaviour of repo a fair bit; firstly, a GRAFANA_VERSION must be specified, otherwise the build will be a no-op.  Then, if the GRAFANA_VERSION begins with the character v, we will package a full release; otherwise we will download and package what ever GRAFANA_VERSION is set to and push it to grafana/grafana-dev.

Also, trigger a deploy to k8s after all this.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>