### PR TITLE
use __FILE as marker for file replacement to avoid issues with variables ending in _FILE

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -46,11 +46,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in _FILE into the content of
-# the file that they point at and use the name without the trailing _FILE.
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"_FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1


### PR DESCRIPTION
Since environment variable names should only consist of uppercase letters, digits, and the '_' (underscore), this PR adjusts the file-replacement syntax to require 2 underscores like `GF_<section>_<setting>__FILE` (with double underscore) so that it isn't ambiguous when the setting ends with `_FILE` (single underscore).