### PR TITLE
Build multiarch (arm64/amd64) grafana docker image

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,6 +1,6 @@
-FROM amd64/debian:stretch-slim
+FROM arm64v8/debian:stretch-slim
 
-ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/master/grafana-latest.linux-x64.tar.gz"
+ARG GRAFANA_URL="https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.2.1.linux-arm64.tar.gz"
 ARG GF_UID="472"
 ARG GF_GID="472"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ Try it out, default admin user is admin/admin.
 
 Further documentation can be found at http://docs.grafana.org/installation/docker/
 
+## Build multiarch docker image for arm64v8 and amd64
+```
+docker build -f Dockerfile.arm64v8 -t grafana/grafana:arm64v8 .
+docker push grafana/grafana:arm64v8
+
+docker build -f Dockerfile -t grafana/grafana:amd64 .
+docker push grafana/grafana:amd64
+
+docker manifest create grafana/grafana:latest grafana/grafana:arm64v8 grafana/grafana:amd64
+docker manifest push grafana/grafana:latest
+```
+
+Now docker will pull correct arch automatically:
+```
+docker run -d --name=grafana -p 3000:3000 grafana/grafana
+```
+
 ## Changelog
 
 ### v5.1.5, v5.2.0-beta2


### PR DESCRIPTION
Now docker will pull correct arch automatically.
Tested on x86_64 (Intel NUC) and arm64v8 (Nvidia Jetson TX2)

Signed-off-by: Abylay Ospan <aospan@netup.ru>